### PR TITLE
Removed etienne/omnibus-4-build from CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
 general:
   branches:
     ignore:
-      - /^(?!etienne).*/
+      - /.*/
   artifacts:
     - "pkg"
 


### PR DESCRIPTION
Because it's the main build now :)
