### PR TITLE
Set a sensible omnibus-ruby version before installing gem deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ RUN git config --global user.email "package@datadoghq.com" && \
     git clone https://github.com/DataDog/dd-agent-omnibus.git
 
 RUN cd dd-agent-omnibus && \
-    linux32 /bin/bash -l -c "bundle install --binstubs"
+    linux32 /bin/bash -l -c "OMNIBUS_RUBY_BRANCH='datadog-5.0.0' bundle install --binstubs"
 
 RUN git clone https://github.com/DataDog/integrations-extras.git
 RUN git clone https://github.com/DataDog/integrations-core.git


### PR DESCRIPTION
Same as https://github.com/DataDog/docker-dd-agent-build-rpm-x64/pull/10
